### PR TITLE
feat: preview support gitea download accelerate

### DIFF
--- a/assets/js/file-download.js
+++ b/assets/js/file-download.js
@@ -52,19 +52,33 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     const downloadAccelerateInput = document.querySelector('.hoa-filetree-download-accelerate');
+    const updatePreviewLink = () => {
+        const previewFileButtons = document.querySelectorAll('.hoa-filetree-preview-link');
+        previewFileButtons.forEach(ele => {
+            let url = ele.closest('.hoa-filetree-file').dataset.url;
+            const downloadAccelerate = downloadAccelerateInput.checked;
+            if (downloadAccelerate) {
+                url = url.replace("gh.hoa.moe/github.com", "gitea.osa.moe");
+                url = url.replace("/raw/", "/raw/branch/");
+            }
+            ele.href = `https://prev.hoa.moe?file=${url}`;
+        });
+    };
     downloadAccelerateInput.addEventListener('click', (e) => {
         localStorage.setItem("downloadAccelerate", e.target.checked ? "on" : "off");
+        updatePreviewLink();
     });
     if (localStorage.getItem("downloadAccelerate") === "on") {
         downloadAccelerateInput.checked = true;
     }
+    updatePreviewLink();
 
     const downloadFileButtons = document.querySelectorAll('.hoa-filetree-download-link');
     downloadFileButtons.forEach(ele => ele.addEventListener('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
         // get link
-        let url = e.target.dataset.url;
+        let url = e.target.closest('.hoa-filetree-file').dataset.url;
         const downloadAccelerate = downloadAccelerateInput.checked;
         if (downloadAccelerate) {
             url = url.replace("gh.hoa.moe/github.com", "gitea.osa.moe");

--- a/assets/js/file-download.js
+++ b/assets/js/file-download.js
@@ -57,11 +57,12 @@ document.addEventListener("DOMContentLoaded", function () {
         previewFileButtons.forEach(ele => {
             let url = ele.closest('.hoa-filetree-file').dataset.url;
             const downloadAccelerate = downloadAccelerateInput.checked;
-            if (downloadAccelerate) {
+            const isMSOfficeFile = /\.(docx?|pptx?|xlsx?)$/.test(url);
+            if (downloadAccelerate && !isMSOfficeFile) {
                 url = url.replace("gh.hoa.moe/github.com", "gitea.osa.moe");
                 url = url.replace("/raw/", "/raw/branch/");
             }
-            ele.href = `https://prev.hoa.moe?file=${url}`;
+            ele.href = `https://prev.hoa.moe?file=${encodeURI(url)}`;
         });
     };
     downloadAccelerateInput.addEventListener('click', (e) => {

--- a/layouts/shortcodes/hoa-filetree/file.html
+++ b/layouts/shortcodes/hoa-filetree/file.html
@@ -11,7 +11,8 @@
 {{- $preview := resources.Get "icons/preview-file.png" -}}
 
 <li data-level="0"
-    class="hoa-filetree-file hx-group/hover hx-flex hx-flex-col hx-list-none hx-w-full hover:hx-bg-gray-100 dark:hover:hx-bg-gray-900 hx-duration-100 hx-cursor-pointer">
+    class="hoa-filetree-file hx-group/hover hx-flex hx-flex-col hx-list-none hx-w-full hover:hx-bg-gray-100 dark:hover:hx-bg-gray-900 hx-duration-100 hx-cursor-pointer"
+    data-url="{{ $url }}">
     <span class="hx-w-full hx-flex hx-cursor-default hx-py-3 hx-text-sm">
         
         <label class="hx-flex hx-w-full hx-items-center hx-justify-between">
@@ -35,8 +36,7 @@
                 <div class="hx-mr-4 hx-hidden md:hx-block hx-flex-1">{{ $date | markdownify }}</div>
                 <a class="hoa-filetree-download-link-wrapper hx-mr-3 hx-z-10 hx-hidden hx-cursor-pointer group-hover/hover:md:hx-block">
                     <img class="hoa-filetree-download-link hx-w-6 hx-h-6 hx-min-w-6"
-                         src="{{ $downloads.RelPermalink }}" alt="downloads"
-                         data-url="{{ $url }}"/>
+                         src="{{ $downloads.RelPermalink }}" alt="downloads"/>
                 </a>
                 <div class="hoa-filetree-download-progress-wrap hx-relative hx-w-6 hx-h-6 hx-mr-3 hx-rounded-full hx-hidden">
                     <div class="hoa-filetree-download-progress hx-rounded-full hx-w-full hx-h-full"></div>
@@ -44,8 +44,7 @@
                     <span class="hoa-filetree-download-progress-text hx-absolute hx-m-auto hx-top-0 hx-bottom-0 hx-left-0 hx-right-0 hx-flex hx-items-center hx-justify-center"
                           style="font-size: 0.5rem;">0</span>
                 </div>
-                <a class="hoa-filetree-preview-link hx-mr-1 md:hx-mr-4 md:hx-hidden hx-w-6 hx-h-6 hx-z-10 hx-min-w-6 md:group-hover/hover:md:hx-block"
-                   href="https://prev.hoa.moe?file={{ $url }}">
+                <a class="hoa-filetree-preview-link hx-mr-1 md:hx-mr-4 md:hx-hidden hx-w-6 hx-h-6 hx-z-10 hx-min-w-6 md:group-hover/hover:md:hx-block">
                     <img class="hx-w-full hx-h-full" src="{{ $preview.RelPermalink }}" alt="preview">
                 </a>
             </span>


### PR DESCRIPTION
## 可能需要讨论和审查的

- 更改 HTML 标签是否有副作用
- 每次开关下载加速都要替换 `href` 开销是否会成为问题
   - 好像还行，因为本身目录就不是特别复杂
   - 我不希望使用 `click` 事件的原因是，`href` 能够实现浏览器自身的跳转功能，更灵活实用