### PR TITLE
ci: use bunx to format spacing in docs

### DIFF
--- a/.github/workflows/course.yaml
+++ b/.github/workflows/course.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Autocorrect Docs
-        run: bunx autocorrect --fix content/
+        run: bunx autocorrect-node --fix content/
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/daily-report.yaml
+++ b/.github/workflows/daily-report.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Autocorrect Docs
-        run: bunx autocorrect --fix content/
+        run: bunx autocorrect-node --fix content/
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/weekly-report.yaml
+++ b/.github/workflows/weekly-report.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Autocorrect Docs
-        run: bunx autocorrect --fix content/
+        run: bunx autocorrect-node --fix content/
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
This will avoid installing the whole package and significantly improve CI time.