### PR TITLE
chore: add wrangler.toml as source of truth

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "hoa-moe"
 pages_build_output_dir = "public"
-compatibility_date = "latest"
+compatibility_date = "2026-01-20"
 
 [placement]
 mode = "smart"


### PR DESCRIPTION
Add Wrangler configuration file following Cloudflare's recommendation to treat it as the [source of truth](https://developers.cloudflare.com/workers/wrangler/configuration/#source-of-truth) for Worker configuration.

This ensures consistent deployment settings and prevents configuration drift between the codebase and Cloudflare dashboard.
